### PR TITLE
Ease requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 nose>=1.1.2
-fudge
 requests>=1.0.0
 simplejson>=2.0
 six>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nose>=1.1.2
-fudge==1.0.3
+fudge
 requests>=1.0.0
 simplejson>=2.0
 six>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,12 @@ setup(
         '': ['README.rst']
     },
     install_requires=[
-        'fudge>=1.0.3',
         'requests>=0.14.0',
         'simplejson>=2.0',
     ],
     tests_require=[
         'nose>=1.1.2',
+        'fudge>=1.0.3',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
It removes the dependency to the `fudge` library and puts it into the `tests_require` section of setup.py.
Intends to fix problems when installing in conda environements failes due to setuptools / 2to3 issue (dropped support).
